### PR TITLE
Add initial Meson build support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 name = "xv6"
 version = "0.1.0"
 authors = ["TODO"]
+edition = "2021"
+rust-version = "1.70"
 
 [lib]
 crate-type = ["staticlib"]

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Prerequisites:
 1. The Rust source (`rustup component add rust-src`).
 
 Building:
-
 1. Run `make`.
+2. Or use Meson with `meson setup build && ninja -C build`.
 
 Running:
 

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,57 @@
+# Meson build file for xv6-rust
+project('xv6-rust', ['c', 'rust', 'cpp'], default_options : ['buildtype=debug'])
+
+# Compiler flags for 32-bit kernel code
+c_args = [
+  '-m32',
+  '-fno-pic',
+  '-fno-builtin',
+  '-fno-strict-aliasing',
+  '-fno-omit-frame-pointer',
+  '-Wall',
+  '-Werror'
+]
+
+asm_args = ['-m32']
+link_args = ['-m32']
+
+# Source files translated from Makefile OBJS list
+c_sources = [
+  'bio.c',
+  'console.c',
+  'exec.c',
+  'file.c',
+  'fs.c',
+  'ide.c',
+  'ioapic.c',
+  'kalloc.c',
+  'lapic.c',
+  'log.c',
+  'main.c',
+  'mp.c',
+  'picirq.c',
+  'pipe.c',
+  'proc.c',
+  'sleeplock.c',
+  'spinlock.c',
+  'swtch.S',
+  'syscall.c',
+  'sysfile.c',
+  'trapasm.S',
+  'trap.c',
+  'vectors.S',
+  'vm.c'
+]
+
+# Build the Rust static library using cargo
+subdir('src')
+
+kernel = executable(
+  'kernel',
+  c_sources,
+  include_directories : include_directories('.'),
+  c_args : c_args,
+  link_args : link_args,
+  dependencies : [rust_lib],
+  link_depends : 'kernel.ld'
+)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,8 @@
+# Build Rust library using cargo xbuild
+cargo = find_program('cargo')
+rust_lib = custom_target(
+  'libxv6',
+  output: 'libxv6.a',
+  command: [cargo, 'xbuild', '--release', '--target', '../i386.json'],
+  build_by_default: true
+)


### PR DESCRIPTION
## Summary
- add `edition` and `rust-version` to `Cargo.toml`
- provide a Meson build script for the kernel
- build the Rust library through Meson
- mention Meson in the build instructions

## Testing
- `meson --version` *(fails: command not found)*
- `cargo build` *(fails to fetch crates: 403 error)*

------
https://chatgpt.com/codex/tasks/task_e_68410a337954833182b47e3dae890ccb