### PR TITLE
Add Doxygen and Sphinx docs

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -68,7 +68,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       =
+OUTPUT_DIRECTORY       = docs/doxygen
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create up to 4096
 # sub-directories (in 2 levels) under the output directory of each output format
@@ -943,7 +943,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = src
+INPUT                  = ..
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -2254,7 +2254,7 @@ MAN_LINKS              = NO
 # captures the structure of the code including all documentation.
 # The default value is: NO.
 
-GENERATE_XML           = NO
+GENERATE_XML           = YES
 
 # The XML_OUTPUT tag is used to specify where the XML pages will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of

--- a/docs/sphinx/source/api.rst
+++ b/docs/sphinx/source/api.rst
@@ -1,0 +1,5 @@
+API Reference
+=============
+
+.. doxygenindex::
+   :project: xv6-rust

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -1,0 +1,40 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'xv6-rust'
+copyright = '2025, Anonymous'
+author = 'Anonymous'
+
+version = '0.1'
+release = '0.1'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.viewcode',
+    'breathe',
+]
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+language = 'en'
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']
+
+# Breathe configuration to include Doxygen output
+breathe_projects = {
+    'xv6-rust': '../../doxygen/xml'
+}
+breathe_default_project = 'xv6-rust'

--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -1,0 +1,22 @@
+.. xv6-rust documentation master file, created by
+   sphinx-quickstart on Mon Jun  9 00:14:52 2025.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to xv6-rust's documentation!
+====================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   api
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/init.c
+++ b/init.c
@@ -1,37 +1,44 @@
 // init: The initial user-level program
 
-#include "types.h"
-#include "stat.h"
-#include "user.h"
 #include "fcntl.h"
+#include "stat.h"
+#include "types.h"
+#include "user.h"
 
-char *argv[] = { "sh", 0 };
+char *argv[] = {"sh", 0};
 
-int
-main(void)
-{
+/**
+ * @brief Entry point for the initial user program.
+ *
+ * Opens the console device if it is missing and launches
+ * the shell in a child process. The parent waits for the
+ * child to exit and logs any zombies.
+ *
+ * @return int Always returns 0.
+ */
+int main(void) {
   int pid, wpid;
 
-  if(open("console", O_RDWR) < 0){
+  if (open("console", O_RDWR) < 0) {
     mknod("console", 1, 1);
     open("console", O_RDWR);
   }
-  dup(0);  // stdout
-  dup(0);  // stderr
+  dup(0); // stdout
+  dup(0); // stderr
 
-  for(;;){
+  for (;;) {
     printf(1, "init: starting sh\n");
     pid = fork();
-    if(pid < 0){
+    if (pid < 0) {
       printf(1, "init: fork failed\n");
       exit();
     }
-    if(pid == 0){
+    if (pid == 0) {
       exec("sh", argv);
       printf(1, "init: exec sh failed\n");
       exit();
     }
-    while((wpid=wait()) >= 0 && wpid != pid)
+    while ((wpid = wait()) >= 0 && wpid != pid)
       printf(1, "zombie!\n");
   }
 }


### PR DESCRIPTION
## Summary
- configure `Doxyfile` to output docs and generate XML
- add new Sphinx documentation using Breathe to import Doxygen XML
- document the `main` function in `init.c`

## Testing
- `apt-get install -y doxygen graphviz python3-sphinx python3-sphinx-rtd-theme`
- `apt-get install -y python3-breathe`
- `doxygen docs/Doxyfile`
- `sphinx-build -b html source build`
- `make` *(fails: `the '-Z' flag is only accepted on the nightly channel`)*

------
https://chatgpt.com/codex/tasks/task_e_6846271b6b408331a7d93d7bd4e28046