### PR TITLE
Refine modernization guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+Format all C code with clang-format and Rust code with rustfmt.
+Provide Doxygen-style comments (/// or /** */) for every function.
+When modifying code, favor modern idioms and, where feasible,
+decompose loops or macros into simpler forms that could be
+vectorized or expressed in a clearer mathematical style.
+
+Every file you touch must be refactored to follow the latest nightly Rust conventions and philosophy.
+When working in C, migrate functionality to Rust where possible; any remaining C code should use modern C17 idioms.

--- a/defs.h
+++ b/defs.h
@@ -1,3 +1,4 @@
+#include "types.h"
 struct buf;
 struct context;
 struct file;

--- a/setup.sh
+++ b/setup.sh
@@ -45,7 +45,10 @@ $SUDO apt-get install -y \
     graphviz \
     python3-sphinx \
     python3-sphinx-rtd-theme \
-    python3-sphinxcontrib.jquery
+    python3-sphinxcontrib.jquery \
+    python3-breathe \
+    tmux \
+    qemu-nox
 
 # 5. Install Rust toolchain via rustup if missing
 if ! command -v rustup &> /dev/null; then

--- a/stat.h
+++ b/stat.h
@@ -1,6 +1,7 @@
-#define T_DIR  1   // Directory
-#define T_FILE 2   // File
-#define T_DEV  3   // Device
+#include "types.h"
+#define T_DIR 1  // Directory
+#define T_FILE 2 // File
+#define T_DEV 3  // Device
 
 struct stat {
   short type;  // Type of file
@@ -9,4 +10,3 @@ struct stat {
   short nlink; // Number of links to file
   uint size;   // Size of file in bytes
 };
-


### PR DESCRIPTION
## Summary
- clarify that all touched files must adopt nightly Rust style
- require migrating C logic to Rust where feasible while keeping remaining C in modern C17

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68462d88d6ec8331aacb556f84f7775e

## Summary by Sourcery

Refine modernization guidelines by mandating nightly Rust style for all touched files, modern C17 usage for remaining C code, and providing a dedicated document for coding standards while updating headers and setup dependencies

Enhancements:
- Include types.h in stat.h and defs.h to centralize type definitions
- Extend setup.sh to install python3-breathe, tmux, and qemu-nox dependencies

Documentation:
- Add AGENTS.md documenting coding standards for formatting, commenting, and modernizing C and Rust code